### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://wgstudio.visualstudio.com/78c4c79d-9894-497d-9851-4a3d399b6ff4/115e9c9e-1161-44c6-8ea4-eea116774c16/_apis/work/boardbadge/6558fd32-f108-4d11-b363-31b321255a8c)](https://wgstudio.visualstudio.com/78c4c79d-9894-497d-9851-4a3d399b6ff4/_boards/board/t/115e9c9e-1161-44c6-8ea4-eea116774c16/Microsoft.RequirementCategory)
 # myrepo


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#155](https://wgstudio.visualstudio.com/78c4c79d-9894-497d-9851-4a3d399b6ff4/_workitems/edit/155). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.